### PR TITLE
FULLCAL-43: After creating an event with dot (.), slash (\), colon(:)…

### DIFF
--- a/macro-fullcalendar-ui/src/main/resources/Calendar/JSONService.xml
+++ b/macro-fullcalendar-ui/src/main/resources/Calendar/JSONService.xml
@@ -80,7 +80,7 @@
       #set ($allDay  = false)
     #end
     #set ($currentResult = {
-      'id'     : $itemdoc.fullName,
+      'id'     : $escapetool.url($itemdoc.fullName),
       'title'  : $itemdoc.plainTitle,
       'url'    : $itemdoc.getExternalURL(),
       'start'  : ${start},


### PR DESCRIPTION
… in the name all events disappear from the Calendar view