### PR TITLE
Fix call to deprecated Velocity directives

### DIFF
--- a/macro-fullcalendar-ui/src/main/resources/Calendar/Macro.xml
+++ b/macro-fullcalendar-ui/src/main/resources/Calendar/Macro.xml
@@ -375,7 +375,7 @@ require(['fullcalendar-setup'], function() {
             #set($calendars = $stringtool.split($gCal, ','))
               #foreach($calendar in $calendars)
                 { googleCalendarId: "$stringtool.strip($calendar)" }
-                #if($velocityCount &lt; $calendars.size())
+                #if($foreach.count &lt; $calendars.size())
                 ,
                 #end
             #end


### PR DESCRIPTION
Since Velocity Engine 1.7, $velocityCount is replaced by $foreach.count (1-based loop index) or $foreach.index (0-based loop index). Using $foreach.count to replace $velocityCount in macro code.