### PR TITLE
FULLCAL-71: Recurrent events are not shown when using iCal URL parameter

### DIFF
--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/FullCalendarManager.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/FullCalendarManager.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.fullcalendar;
 
+import java.net.URL;
 import java.util.Date;
 
 import org.xwiki.component.annotation.Role;
@@ -34,22 +35,22 @@ public interface FullCalendarManager
 {
     /**
      * Convert an iCal to a JSON.
-     * 
+     *
      * @param iCalStringURL the String representation of an iCal URL.
      * @return the JSON representation of a calendar.
-     * @throws Exception in case of exceptions.
+     * @throws Exception if the retrieval of the iCal fails or if it contains malformed dates.
      */
     String iCalToJSON(String iCalStringURL) throws Exception;
 
     /**
-     * Convert an iCal to a JSON.
+     * Get the events from an iCal in a specified date interval. This method expands the recurring events.
      *
      * @param iCalStringURL the String representation of an iCal URL.
      * @param startDate the start of the interval of the returned calendar events.
      * @param endDate the end of the interval.
-     * @return the JSON representation of a calendar.
-     * @throws Exception in case of exceptions.
+     * @return a JSON that contains a list of FullCalendar Event Objects.
+     * @throws Exception if the retrieval of the iCal fails or if it contains malformed dates.
      * @since 2.3
      */
-    String iCalToJSON(String iCalStringURL, Date startDate, Date endDate) throws Exception;
+    String getICalEvents(URL iCalStringURL, Date startDate, Date endDate) throws Exception;
 }

--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/FullCalendarManager.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/FullCalendarManager.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.fullcalendar;
 
+import java.util.Date;
+
 import org.xwiki.component.annotation.Role;
 
 /**
@@ -38,4 +40,16 @@ public interface FullCalendarManager
      * @throws Exception in case of exceptions.
      */
     String iCalToJSON(String iCalStringURL) throws Exception;
+
+    /**
+     * Convert an iCal to a JSON.
+     *
+     * @param iCalStringURL the String representation of an iCal URL.
+     * @param startDate the start of the interval of the returned calendar events.
+     * @param endDate the end of the interval.
+     * @return the JSON representation of a calendar.
+     * @throws Exception in case of exceptions.
+     * @since 2.3
+     */
+    String iCalToJSON(String iCalStringURL, Date startDate, Date endDate) throws Exception;
 }

--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/DefaultFullCalendarManager.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/DefaultFullCalendarManager.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,17 +42,21 @@ import org.xwiki.velocity.tools.JSONTool;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.model.Calendar;
+import net.fortuna.ical4j.model.Date;
+import net.fortuna.ical4j.model.DateList;
 import net.fortuna.ical4j.model.DateTime;
 import net.fortuna.ical4j.model.TimeZone;
 import net.fortuna.ical4j.model.TimeZoneRegistry;
 import net.fortuna.ical4j.model.component.CalendarComponent;
 import net.fortuna.ical4j.model.component.VEvent;
 import net.fortuna.ical4j.model.component.VTimeZone;
+import net.fortuna.ical4j.model.parameter.Value;
+import net.fortuna.ical4j.model.property.RRule;
 import net.fortuna.ical4j.util.CompatibilityHints;
 
 /**
  * Default implementation for {@link FullCalendarManager}.
- * 
+ *
  * @version $Id$
  * @since 2.1
  */
@@ -61,8 +66,12 @@ public class DefaultFullCalendarManager implements FullCalendarManager
 {
     private static final String T_VALUE = "T";
 
+    private static final String START_DATE_JSON_KEY = "start";
+
+    private static final String END_DATE_JSON_KEY = "end";
+
     // FullCalendar will accept ISO8601 date strings written with hours, minutes, seconds, and milliseconds.
-    private DateFormat jsonDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss");
+    private final DateFormat jsonDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss");
 
     @Inject
     private Logger logger;
@@ -70,6 +79,15 @@ public class DefaultFullCalendarManager implements FullCalendarManager
     @Override
     public String iCalToJSON(String iCalStringURL) throws Exception
     {
+        return iCalToJSON(iCalStringURL, null, null);
+    }
+
+    @Override
+    public String iCalToJSON(String iCalStringURL, java.util.Date intervalStart, java.util.Date intervalEnd)
+        throws Exception
+    {
+        Date icalIntervalStart = intervalStart == null ? null : new Date(intervalStart);
+        Date icalIntervalEnd = intervalEnd == null ? null : new Date(intervalEnd);
         CalendarBuilder builder = new CalendarBuilder();
         Calendar calendar = getCalendar(iCalStringURL, builder);
 
@@ -81,11 +99,19 @@ public class DefaultFullCalendarManager implements FullCalendarManager
 
         List<CalendarComponent> events = calendar.getComponents(net.fortuna.ical4j.model.Component.VEVENT);
 
+        addEvents(events, timeZone, icalIntervalStart, icalIntervalEnd, jsonArrayList);
+
+        return new JSONTool().serialize(jsonArrayList);
+    }
+
+    private void addEvents(List<CalendarComponent> events, TimeZone timeZone, Date icalIntervalStart,
+        Date icalIntervalEnd, ArrayList<Object> jsonArrayList) throws ParseException
+    {
         for (CalendarComponent eventComponent : events) {
             VEvent event = (VEvent) eventComponent;
             Map<String, Object> jsonMap = new HashMap<>();
-            jsonMap.put("id", event.getUid() == null ? "" : event.getUid().getValue());
-            jsonMap.put("title", event.getSummary() == null ? "" : event.getSummary().getValue());
+
+            addBasicProperties(jsonMap, event);
 
             String startDateValue = event.getStartDate() == null ? "" : event.getStartDate().getValue();
             String endDateValue = event.getEndDate() == null ? "" : event.getEndDate().getValue();
@@ -96,20 +122,68 @@ public class DefaultFullCalendarManager implements FullCalendarManager
             jsonMap.put("allDay", !allDay);
 
             DateTime startDateTime = new DateTime(startDateValue, timeZone);
-            jsonMap.put("start", jsonDateFormat.format(startDateTime));
-
             DateTime endDateTime = new DateTime(endDateValue, timeZone);
-            jsonMap.put("end", jsonDateFormat.format(endDateTime));
+            // Do not add the event if it's not in the interval.
+            long differenceInMillis = endDateTime.getTime() - startDateTime.getTime();
 
-            // Non-standard fields in each Event Object. FullCalendar will not modify or delete these fields.
-            jsonMap.put("description", event.getDescription() == null ? "" : event.getDescription().getValue());
-            jsonMap.put("location", event.getLocation() == null ? "" : event.getLocation().getValue());
-            jsonMap.put("status", event.getStatus() == null ? "" : event.getStatus().getValue());
+            // If the interval dates are null, maintain backwards compatibility.
+            if (icalIntervalStart == null || icalIntervalEnd == null || areIntervalsIntersected(startDateTime,
+                endDateTime, icalIntervalStart, icalIntervalEnd))
+            {
+                jsonMap.put(START_DATE_JSON_KEY, jsonDateFormat.format(startDateTime));
+                jsonMap.put(END_DATE_JSON_KEY, jsonDateFormat.format(endDateTime));
+                jsonArrayList.add(jsonMap);
+            }
 
-            jsonArrayList.add(jsonMap);
+            addRecurringEvents(event, icalIntervalStart, icalIntervalEnd, jsonMap, timeZone, differenceInMillis,
+                jsonArrayList);
         }
+    }
 
-        return new JSONTool().serialize(jsonArrayList);
+    private static void addBasicProperties(Map<String, Object> jsonMap, VEvent event)
+    {
+        jsonMap.put("id", event.getUid() == null ? "" : event.getUid().getValue());
+        jsonMap.put("title", event.getSummary() == null ? "" : event.getSummary().getValue());
+
+        // Non-standard fields in each Event Object. FullCalendar will not modify or delete these fields.
+        jsonMap.put("description", event.getDescription() == null ? "" : event.getDescription().getValue());
+        jsonMap.put("location", event.getLocation() == null ? "" : event.getLocation().getValue());
+        jsonMap.put("status", event.getStatus() == null ? "" : event.getStatus().getValue());
+    }
+
+    private void addRecurringEvents(VEvent event, Date icalIntervalStart, Date icalIntervalEnd,
+        Map<String, Object> jsonMap, TimeZone timeZone, long differenceInMillis, ArrayList<Object> jsonArrayList)
+    {
+        // If the interval dates are null, we don't check for recurring events. Done in order to maintain backwards
+        // compatibility.
+        if (icalIntervalStart == null || icalIntervalEnd == null) {
+            return;
+        }
+        // Create the recurring events based on the existing RRule.
+        RRule rRule = event.getProperty("rrule");
+        if (rRule != null && rRule.getRecur() != null) {
+            DateList recurringEventStartDates = rRule.getRecur()
+                .getDates(event.getStartDate().getDate(), icalIntervalStart, icalIntervalEnd, Value.DATE);
+            for (Date recurringEventStartDate : recurringEventStartDates) {
+                if (recurringEventStartDate.equals(event.getStartDate().getDate())) {
+                    continue;
+                }
+                Map<String, Object> recurringEvent = new HashMap<>(jsonMap);
+
+                recurringEvent.put(START_DATE_JSON_KEY,
+                    jsonDateFormat.format(new DateTime(recurringEventStartDate, timeZone)));
+                recurringEvent.put(END_DATE_JSON_KEY, jsonDateFormat.format(
+                    new DateTime(new Date(recurringEventStartDate.getTime() + differenceInMillis), timeZone)));
+                jsonArrayList.add(recurringEvent);
+            }
+        }
+    }
+
+    private boolean areIntervalsIntersected(Date intervalStart1, Date intervalEnd1, Date intervalStart2,
+        Date intervalEnd2)
+    {
+        return (intervalEnd1.after(intervalStart2) && intervalEnd1.before(intervalEnd2))
+            || (intervalStart1.after(intervalStart2) && intervalStart1.before(intervalEnd2));
     }
 
     private Calendar getCalendar(String iCalStringURL, CalendarBuilder builder) throws Exception
@@ -121,7 +195,7 @@ public class DefaultFullCalendarManager implements FullCalendarManager
         URLConnection conn = iCalURL.openConnection();
         InputStream is = conn.getInputStream();
         if (logger.isDebugEnabled()) {
-            logger.debug("InputStream: {}", IOUtils.toString(is, StandardCharsets.UTF_8.name()));
+            logger.debug("InputStream: {}", IOUtils.toString(is, StandardCharsets.UTF_8));
         }
 
         Calendar calendar = builder.build(is);

--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/DefaultFullCalendarManager.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/DefaultFullCalendarManager.java
@@ -38,7 +38,8 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.fullcalendar.FullCalendarManager;
-import org.xwiki.velocity.tools.JSONTool;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.fortuna.ical4j.data.CalendarBuilder;
 import net.fortuna.ical4j.model.Calendar;
@@ -66,11 +67,13 @@ public class DefaultFullCalendarManager implements FullCalendarManager
 {
     private static final String T_VALUE = "T";
 
-    private static final String ID_JSON_KEY = "id";
+    private static final String JSON_KEY_ID = "id";
 
-    private static final String START_DATE_JSON_KEY = "start";
+    private static final String JSON_KEY_START_DATE = "start";
 
-    private static final String END_DATE_JSON_KEY = "end";
+    private static final String JSON_KEY_END_DATE = "end";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     // FullCalendar will accept ISO8601 date strings written with hours, minutes, seconds, and milliseconds.
     private final DateFormat jsonDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss");
@@ -81,17 +84,17 @@ public class DefaultFullCalendarManager implements FullCalendarManager
     @Override
     public String iCalToJSON(String iCalStringURL) throws Exception
     {
-        return iCalToJSON(iCalStringURL, null, null);
+        return getICalEvents(new URL(iCalStringURL), null, null);
     }
 
     @Override
-    public String iCalToJSON(String iCalStringURL, java.util.Date intervalStart, java.util.Date intervalEnd)
+    public String getICalEvents(URL iCalURL, java.util.Date intervalStart, java.util.Date intervalEnd)
         throws Exception
     {
         Date icalIntervalStart = intervalStart == null ? null : new Date(intervalStart);
         Date icalIntervalEnd = intervalEnd == null ? null : new Date(intervalEnd);
         CalendarBuilder builder = new CalendarBuilder();
-        Calendar calendar = getCalendar(iCalStringURL, builder);
+        Calendar calendar = getCalendar(iCalURL, builder);
 
         TimeZoneRegistry timeZoneRegistry = builder.getRegistry();
         String timeZoneValue = getTimeZoneValue(calendar);
@@ -102,8 +105,7 @@ public class DefaultFullCalendarManager implements FullCalendarManager
         List<CalendarComponent> events = calendar.getComponents(net.fortuna.ical4j.model.Component.VEVENT);
 
         addEvents(events, timeZone, icalIntervalStart, icalIntervalEnd, jsonArrayList);
-
-        return new JSONTool().serialize(jsonArrayList);
+        return MAPPER.writeValueAsString(jsonArrayList);
     }
 
     private void addEvents(List<CalendarComponent> events, TimeZone timeZone, Date icalIntervalStart,
@@ -113,7 +115,7 @@ public class DefaultFullCalendarManager implements FullCalendarManager
             VEvent event = (VEvent) eventComponent;
             Map<String, Object> jsonMap = new HashMap<>();
 
-            addBasicProperties(jsonMap, event);
+            addBasicEventProperties(jsonMap, event);
 
             String startDateValue = event.getStartDate() == null ? "" : event.getStartDate().getValue();
             String endDateValue = event.getEndDate() == null ? "" : event.getEndDate().getValue();
@@ -132,19 +134,24 @@ public class DefaultFullCalendarManager implements FullCalendarManager
             if (icalIntervalStart == null || icalIntervalEnd == null || areIntervalsIntersected(startDateTime,
                 endDateTime, icalIntervalStart, icalIntervalEnd))
             {
-                jsonMap.put(START_DATE_JSON_KEY, jsonDateFormat.format(startDateTime));
-                jsonMap.put(END_DATE_JSON_KEY, jsonDateFormat.format(endDateTime));
+                jsonMap.put(JSON_KEY_START_DATE, jsonDateFormat.format(startDateTime));
+                jsonMap.put(JSON_KEY_END_DATE, jsonDateFormat.format(endDateTime));
                 jsonArrayList.add(jsonMap);
             }
 
+            // If the interval dates are null, we don't check for recurring events. Done in order to maintain backwards
+            // compatibility.
+            if (icalIntervalStart == null || icalIntervalEnd == null) {
+                return;
+            }
             addRecurringEvents(event, icalIntervalStart, icalIntervalEnd, jsonMap, timeZone, differenceInMillis,
                 jsonArrayList);
         }
     }
 
-    private static void addBasicProperties(Map<String, Object> jsonMap, VEvent event)
+    private static void addBasicEventProperties(Map<String, Object> jsonMap, VEvent event)
     {
-        jsonMap.put(ID_JSON_KEY, event.getUid() == null ? "" : event.getUid().getValue());
+        jsonMap.put(JSON_KEY_ID, event.getUid() == null ? "" : event.getUid().getValue());
         jsonMap.put("title", event.getSummary() == null ? "" : event.getSummary().getValue());
 
         // Non-standard fields in each Event Object. FullCalendar will not modify or delete these fields.
@@ -156,28 +163,23 @@ public class DefaultFullCalendarManager implements FullCalendarManager
     private void addRecurringEvents(VEvent event, Date icalIntervalStart, Date icalIntervalEnd,
         Map<String, Object> jsonMap, TimeZone timeZone, long differenceInMillis, ArrayList<Object> jsonArrayList)
     {
-        // If the interval dates are null, we don't check for recurring events. Done in order to maintain backwards
-        // compatibility.
-        if (icalIntervalStart == null || icalIntervalEnd == null) {
-            return;
-        }
         // Create the recurring events based on the existing RRule.
         RRule rRule = event.getProperty("rrule");
         if (rRule != null && rRule.getRecur() != null) {
             DateList recurringEventStartDates = rRule.getRecur()
                 .getDates(event.getStartDate().getDate(), icalIntervalStart, icalIntervalEnd, Value.DATE);
-            String groupId = String.format("%s_group", jsonMap.get(ID_JSON_KEY));
+            String groupId = String.format("%s_group", jsonMap.get(JSON_KEY_ID));
             for (int i = 0; i < recurringEventStartDates.size(); i++) {
                 if (recurringEventStartDates.get(i).equals(event.getStartDate().getDate())) {
                     continue;
                 }
                 Map<String, Object> recurringEvent = new HashMap<>(jsonMap);
 
-                recurringEvent.put(START_DATE_JSON_KEY,
+                recurringEvent.put(JSON_KEY_START_DATE,
                     jsonDateFormat.format(new DateTime(recurringEventStartDates.get(i), timeZone)));
-                recurringEvent.put(END_DATE_JSON_KEY, jsonDateFormat.format(
+                recurringEvent.put(JSON_KEY_END_DATE, jsonDateFormat.format(
                     new DateTime(new Date(recurringEventStartDates.get(i).getTime() + differenceInMillis), timeZone)));
-                recurringEvent.put(ID_JSON_KEY, String.format("%s_%d", jsonMap.get(ID_JSON_KEY), i));
+                recurringEvent.put(JSON_KEY_ID, String.format("%s_%d", jsonMap.get(JSON_KEY_ID), i));
                 recurringEvent.put("groupId", groupId);
                 jsonArrayList.add(recurringEvent);
             }
@@ -191,10 +193,8 @@ public class DefaultFullCalendarManager implements FullCalendarManager
             || (intervalStart1.after(intervalStart2) && intervalStart1.before(intervalEnd2));
     }
 
-    private Calendar getCalendar(String iCalStringURL, CalendarBuilder builder) throws Exception
+    private Calendar getCalendar(URL iCalURL, CalendarBuilder builder) throws Exception
     {
-        URL iCalURL = new URL(iCalStringURL);
-
         CompatibilityHints.setHintEnabled(CompatibilityHints.KEY_RELAXED_PARSING, true);
 
         URLConnection conn = iCalURL.openConnection();

--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/script/FullCalendarScriptService.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/script/FullCalendarScriptService.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.fullcalendar.script;
 
+import java.net.URL;
 import java.util.Date;
 
 import javax.inject.Inject;
@@ -31,7 +32,7 @@ import org.xwiki.script.service.ScriptService;
 
 /**
  * Exposes simplified APIs to perform calendar operations.
- * 
+ *
  * @version $Id$
  * @since 2.1
  */
@@ -48,7 +49,7 @@ public class FullCalendarScriptService implements ScriptService
      *
      * @param iCalStringURL the String representation of an iCal URL.
      * @return the JSON representation of a calendar.
-     * @throws Exception in case of exceptions.
+     * @throws Exception if the retrieval of the iCal fails or if it contains malformed dates.
      */
     public String iCalToJSON(String iCalStringURL) throws Exception
     {
@@ -56,16 +57,17 @@ public class FullCalendarScriptService implements ScriptService
     }
 
     /**
-     * Convert an iCal to a JSON.
+     * Get the events from an iCal in a specified date interval. This method expands the recurring events.
      *
      * @param iCalStringURL the String representation of an iCal URL.
-     * @param startDate the beginning of the interval in which the returned events should be.
+     * @param startDate the start of the interval of the returned calendar events.
      * @param endDate the end of the interval.
-     * @return the JSON representation of a calendar.
-     * @throws Exception in case of exceptions.
+     * @return a JSON that contains a list of FullCalendar Event Objects.
+     * @throws Exception if the retrieval of the iCal fails or if it contains malformed dates.
      * @since 2.3
      */
-    public String iCalToJSON(String iCalStringURL, Date startDate, Date endDate) throws Exception {
-        return fullCalendarManager.iCalToJSON(iCalStringURL, startDate, endDate);
+    public String getICalEvents(String iCalStringURL, Date startDate, Date endDate) throws Exception
+    {
+        return fullCalendarManager.getICalEvents(new URL(iCalStringURL), startDate, endDate);
     }
 }

--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/script/FullCalendarScriptService.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/script/FullCalendarScriptService.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.fullcalendar.script;
 
+import java.util.Date;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -51,5 +53,19 @@ public class FullCalendarScriptService implements ScriptService
     public String iCalToJSON(String iCalStringURL) throws Exception
     {
         return fullCalendarManager.iCalToJSON(iCalStringURL);
+    }
+
+    /**
+     * Convert an iCal to a JSON.
+     *
+     * @param iCalStringURL the String representation of an iCal URL.
+     * @param startDate the beginning of the interval in which the returned events should be.
+     * @param endDate the end of the interval.
+     * @return the JSON representation of a calendar.
+     * @throws Exception in case of exceptions.
+     * @since 2.3
+     */
+    public String iCalToJSON(String iCalStringURL, Date startDate, Date endDate) throws Exception {
+        return fullCalendarManager.iCalToJSON(iCalStringURL, startDate, endDate);
     }
 }

--- a/macro-fullcalendar-ui/src/main/resources/Calendar/ICalToJSON.xml
+++ b/macro-fullcalendar-ui/src/main/resources/Calendar/ICalToJSON.xml
@@ -44,7 +44,7 @@
   $response.setContentType('application/json')
   #set ($format = "yyyy-MM-dd")
   ## Display the JSON content.
-  $services.fullcalendar.iCalToJSON($request.iCal, $datetool.toDate($format, $request.start), $datetool.toDate($format, $request.end))
+  $services.fullcalendar.getICalEvents($request.iCal, $datetool.toDate($format, $request.start), $datetool.toDate($format, $request.end))
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/macro-fullcalendar-ui/src/main/resources/Calendar/ICalToJSON.xml
+++ b/macro-fullcalendar-ui/src/main/resources/Calendar/ICalToJSON.xml
@@ -42,8 +42,9 @@
   <content>{{velocity wiki="false"}}
 #if ($xcontext.action == 'get' &amp;&amp; "$!{request.outputSyntax}" == 'plain')
   $response.setContentType('application/json')
+  #set ($format = "yyyy-MM-dd")
   ## Display the JSON content.
-  $services.fullcalendar.iCalToJSON($request.iCal)
+  $services.fullcalendar.iCalToJSON($request.iCal, $datetool.toDate($format, $request.start), $datetool.toDate($format, $request.end))
 #end
 {{/velocity}}</content>
 </xwikidoc>


### PR DESCRIPTION
PR for the fix of [FULLCAL-71](https://jira.xwiki.org/browse/FULLCAL-71)

The google calendar:
![image](https://github.com/xwiki-contrib/macro-fullcalendar/assets/45433221/d538a1de-dabc-45d3-a21b-dafa3a3e6a10)

The imported calendar:
![image](https://github.com/xwiki-contrib/macro-fullcalendar/assets/45433221/7dce4bbe-7ceb-4e05-864f-bb6a7e6e0b89)
