### PR TITLE
FULLCAL-78: Add default time zone to CalendarReader class

### DIFF
--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/CalendarReader.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/CalendarReader.java
@@ -95,6 +95,9 @@ public class CalendarReader
     public TimeZone getTimeZone()
     {
         String timeZoneValue = getTimeZoneValue(calendar);
+        if (timeZoneValue.isEmpty()) {
+            return builder.getRegistry().getTimeZone(TimeZone.getDefault().getID());
+        }
         return builder.getRegistry().getTimeZone(timeZoneValue);
     }
 


### PR DESCRIPTION
Added a check for a missing time zone for those situations when the time zone is not specified in the calendar.