### PR TITLE
FULLCAL-79: Event times shift since v2.4.0

### DIFF
--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/model/CalendarEvent.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/model/CalendarEvent.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import org.xwiki.stability.Unstable;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * Represents the data of a mocca calendar event.
  *
@@ -38,8 +40,10 @@ public class CalendarEvent
 
     private String title;
 
+    @JsonSerialize(using = CustomDateSerializer.class)
     private Date start;
 
+    @JsonSerialize(using = CustomDateSerializer.class)
     private Date end;
 
     private boolean allDay;
@@ -351,12 +355,12 @@ public class CalendarEvent
     }
 
     /**
-     * Get the time difference between the event start date and the event end date.
+     * Get the time difference between the event end date and the event start date.
      *
-     * @return the time difference between the event start date and the event end date.
+     * @return the time difference between the event end date and the event start date.
      */
     public long getDatesDifference()
     {
-        return start.getTime() - end.getTime();
+        return end.getTime() - start.getTime();
     }
 }

--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/model/CustomDateSerializer.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/model/CustomDateSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.fullcalendar.model;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.xwiki.stability.Unstable;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Custom serializer for {@link Date} objects. Uses a {@link SimpleDateFormat} to format the object into a string with
+ * the pattern: "yyyy-MM-dd'T'HH:mm:ss.sss".
+ *
+ * @version $Id$
+ * @since 2.4.3
+ */
+@Unstable
+public class CustomDateSerializer extends JsonSerializer<Date>
+{
+    private final DateFormat jsonDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss");
+
+    @Override
+    public void serialize(Date value, JsonGenerator gen, SerializerProvider serializers) throws IOException
+    {
+        gen.writeString(value != null ? jsonDateFormat.format(value) : null);
+    }
+}


### PR DESCRIPTION
Previously, the serialization returned the time of the date, which when processed by `fullcalendar.min.js` it seems to reset the time zone to UTC. To prevent this, I restored the [old start and end time](https://github.com/xwiki-contrib/macro-fullcalendar/commit/0a68966e37630fdfdb1518a2fdd595a8377fe559#diff-7506404b90c467add72b52b4b923657e0f508d022675c6f9b378667092e9f975L137-L138) (lines 137-138 from DefaultFullCalendarManager) serialization format so that the time zone is correctly processed.

Modified the `getDatesDifference` function from `CalendarEvents` class to return the difference between end date and start date.