### PR TITLE
[FULLCAL-87]: Hardcoded recurrent event duration

### DIFF
--- a/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/util/RecurrenceProcessor.java
+++ b/macro-fullcalendar-api/src/main/java/org/xwiki/fullcalendar/internal/util/RecurrenceProcessor.java
@@ -192,8 +192,7 @@ public class RecurrenceProcessor
                 jsonMap.getStart().getTime() + recurCount * TIME_PERIODS.getOrDefault(recur.getFrequency().name(),
                     YEARLY_DURATION)));
         } else {
-            // Set end date of recurrence to five years from now.
-            jsonMap.setRecEndDate(new DateTime(jsonMap.getStart().getTime() + 5 * YEARLY_DURATION));
+            jsonMap.setRecEndDate(null);
         }
     }
 


### PR DESCRIPTION
Removed the 5 year recurrency limit.

Now, the recurrency limit is set to null when no limit is found, making the recurrency infinite.